### PR TITLE
uint16_t -> int32_t 支持行数超过65535的文件

### DIFF
--- a/src/clang_tu.cc
+++ b/src/clang_tu.cc
@@ -59,7 +59,7 @@ static Pos decomposed2LineAndCol(const SourceManager &sm,
         while (i < p.size() && (uint8_t)p[i] >= 128 && (uint8_t)p[i] < 192)
           i++;
   }
-  return {(uint16_t)std::min<int>(l, UINT16_MAX),
+  return {(int32_t)std::min<int>(l, INT32_MAX),
           (int16_t)std::min<int>(c, INT16_MAX)};
 }
 

--- a/src/config.hh
+++ b/src/config.hh
@@ -62,6 +62,15 @@ struct Config {
     // 0: never retain; 1: retain after initial load; 2: retain after 2 loads
     // (initial load+first save)
     int retainInMemory = 2;
+
+    // When handling an initialize request from the client, full load the cache
+    // before starting the index process. Note: The expired caches are also
+    // loaded. So it may be inaccurate until the index process is actually
+    // complete.
+    // The main purpose of turning this option on is to start working quickly
+    // with a less accurate (but mostly accurate) cache without waiting for the
+    // slow index process.
+    bool fullLoadOnInitialize = false;
   } cache;
 
   struct ServerCap {
@@ -322,7 +331,7 @@ struct Config {
   } xref;
 };
 REFLECT_STRUCT(Config::Cache, directory, format, hierarchicalPath,
-               retainInMemory);
+               retainInMemory, fullLoadOnInitialize);
 REFLECT_STRUCT(Config::ServerCap::DocumentOnTypeFormattingOptions,
                firstTriggerCharacter, moreTriggerCharacter);
 REFLECT_STRUCT(Config::ServerCap::Workspace::WorkspaceFolders, supported,

--- a/src/message_handler.cc
+++ b/src/message_handler.cc
@@ -319,9 +319,9 @@ void emitSemanticHighlight(DB *db, WorkingFile *wfile, QueryFile &file) {
       // but we still want to keep the range for jumping to definition.
       std::string_view concise_name =
           detailed_name.substr(0, detailed_name.find('<'));
-      uint16_t start_line = sym.range.start.line;
+      int32_t start_line = sym.range.start.line;
       int16_t start_col = sym.range.start.column;
-      if (start_line >= wfile->index_lines.size())
+      if (start_line >= (int32_t)wfile->index_lines.size())
         continue;
       std::string_view line = wfile->index_lines[start_line];
       sym.range.end.line = start_line;

--- a/src/messages/ccls_navigate.cc
+++ b/src/messages/ccls_navigate.cc
@@ -38,7 +38,7 @@ void MessageHandler::ccls_navigate(JsonReader &reader, ReplyOnce &reply) {
     if (auto line =
             wf->getIndexPosFromBufferPos(ls_pos.line, &ls_pos.character, false))
       ls_pos.line = *line;
-  Pos pos{(uint16_t)ls_pos.line, (int16_t)ls_pos.character};
+  Pos pos{(int32_t)ls_pos.line, (int16_t)ls_pos.character};
 
   Maybe<Range> res;
   switch (param.direction[0]) {

--- a/src/pipeline.hh
+++ b/src/pipeline.hh
@@ -43,10 +43,15 @@ struct IndexStats {
   std::atomic<int64_t> last_idle, completed, enqueued;
 };
 
+struct LoadCacheStats {
+  std::atomic<int64_t> completed, enqueued;
+};
+
 namespace pipeline {
 extern std::atomic<bool> g_quit;
 extern std::atomic<int64_t> loaded_ts;
 extern IndexStats stats;
+extern LoadCacheStats load_cache_stats;
 extern int64_t tick;
 
 void threadEnter();
@@ -61,6 +66,7 @@ void standalone(const std::string &root);
 
 void index(const std::string &path, const std::vector<const char *> &args,
            IndexMode mode, bool must_exist, RequestId id = {});
+void loadCache(const std::string &path);
 void removeCache(const std::string &path);
 std::optional<std::string> loadIndexedContent(const std::string &path);
 

--- a/src/position.cc
+++ b/src/position.cc
@@ -16,7 +16,7 @@
 namespace ccls {
 Pos Pos::fromString(const std::string &encoded) {
   char *p = const_cast<char *>(encoded.c_str());
-  uint16_t line = uint16_t(strtoul(p, &p, 10) - 1);
+  int32_t line = int32_t(strtoul(p, &p, 10) - 1);
   assert(*p == ':');
   p++;
   int16_t column = int16_t(strtol(p, &p, 10)) - 1;
@@ -32,14 +32,14 @@ std::string Pos::toString() {
 Range Range::fromString(const std::string &encoded) {
   Pos start, end;
   char *p = const_cast<char *>(encoded.c_str());
-  start.line = uint16_t(strtoul(p, &p, 10) - 1);
+  start.line = int32_t(strtoul(p, &p, 10) - 1);
   assert(*p == ':');
   p++;
   start.column = int16_t(strtol(p, &p, 10)) - 1;
   assert(*p == '-');
   p++;
 
-  end.line = uint16_t(strtoul(p, &p, 10) - 1);
+  end.line = int32_t(strtoul(p, &p, 10) - 1);
   assert(*p == ':');
   p++;
   end.column = int16_t(strtol(p, nullptr, 10)) - 1;
@@ -47,9 +47,9 @@ Range Range::fromString(const std::string &encoded) {
 }
 
 bool Range::contains(int line, int column) const {
-  if (line > UINT16_MAX)
+  if (line > INT32_MAX)
     return false;
-  Pos p{(uint16_t)line, (int16_t)std::min<int>(column, INT16_MAX)};
+  Pos p{(int32_t)line, (int16_t)std::min<int>(column, INT16_MAX)};
   return !(p < start) && p < end;
 }
 

--- a/src/position.hh
+++ b/src/position.hh
@@ -10,7 +10,7 @@
 
 namespace ccls {
 struct Pos {
-  uint16_t line = 0;
+  int32_t line = 0;
   int16_t column = -1;
 
   static Pos fromString(const std::string &encoded);
@@ -73,7 +73,7 @@ template <> struct hash<ccls::Range> {
       ccls::Range range;
       uint64_t u64;
     } u{x};
-    static_assert(sizeof(ccls::Range) == 8);
+    static_assert(sizeof(ccls::Range) == 16);
     return hash<uint64_t>()(u.u64);
   }
 };

--- a/src/project.cc
+++ b/src/project.cc
@@ -591,6 +591,13 @@ Project::Entry Project::findEntry(const std::string &path, bool can_redirect,
   return ret;
 }
 
+void Project::fullLoadCache() {
+  std::lock_guard lock(mtx);
+  for (auto &[root, folder] : root2folder)
+    for (const Project::Entry &entry : folder.entries)
+      pipeline::loadCache(entry.filename);
+}
+
 void Project::index(WorkingFiles *wfiles, const RequestId &id) {
   auto &gi = g_config->index;
   GroupMatch match(gi.whitelist, gi.blacklist),

--- a/src/project.hh
+++ b/src/project.hh
@@ -66,5 +66,6 @@ struct Project {
 
   void index(WorkingFiles *wfiles, const RequestId &id);
   void indexRelated(const std::string &path);
+  void fullLoadCache();
 };
 } // namespace ccls


### PR DESCRIPTION
Merge commits from @xinghun.
uint16_t -> int32_t supports files with more than 65535 lines
Added the option to fully load the cache first during initialization